### PR TITLE
Fix hyphen formatting in database schema overview

### DIFF
--- a/docs/database_schema.md
+++ b/docs/database_schema.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The NoxGuard---NoxPanel database system provides a comprehensive data storage solution for network management, knowledge management, AI conversations, and user sessions. Built on SQLite with connection pooling and migration support.
+The NoxGuard-NoxPanel database system provides a comprehensive data storage solution for network management, knowledge management, AI conversations, and user sessions. Built on SQLite with connection pooling and migration support.
 
 ## Database Architecture
 


### PR DESCRIPTION
## Summary
- correct triple hyphen to single hyphen in database schema overview

## Testing
- `pre-commit run --files docs/database_schema.md` *(fails: Found 2 critical issues)*
- `pytest` *(fails: TestDatabaseAdmin::test_export_import_data)*

------
https://chatgpt.com/codex/tasks/task_b_6895908e73208331a03602a6c36d5e2d