### PR TITLE
Add timedelta import for installer utilities

### DIFF
--- a/noxsuite_installer_utils.py
+++ b/noxsuite_installer_utils.py
@@ -12,7 +12,7 @@ import hashlib
 import yaml
 from pathlib import Path
 from typing import Dict, List, Optional, Any, Union
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 
 class ProgressTracker:
     """Enhanced progress tracking with ETA calculation"""


### PR DESCRIPTION
## Summary
- import `timedelta` alongside `datetime` and `timezone` in `noxsuite_installer_utils`

## Testing
- `pre-commit run --files noxsuite_installer_utils.py` *(fails: flake8, bandit, etc.)*
- `pytest` *(fails: TestDatabaseAdmin::test_export_import_data)*

------
https://chatgpt.com/codex/tasks/task_b_6895908fce7883318ebbf75e30452826