### PR TITLE
docs: fix startup script reference

### DIFF
--- a/NOXSUITE_README.md
+++ b/NOXSUITE_README.md
@@ -95,8 +95,8 @@ The installer will:
 # Run the setup script
 ./setup-noxsuite.sh
 
-# Start all services
-./scripts/start-noxsuite.sh
+# Start services with Docker Compose
+docker-compose -f docker-compose.noxsuite.yml --profile ai up -d
 ```
 
 ### Option 3: Manual Docker Compose


### PR DESCRIPTION
## Summary
- remove reference to non-existent `start-noxsuite.sh`
- instruct users to start services via Docker Compose

## Testing
- `pytest` *(fails: Data export failed: unable to open database file)*

------
https://chatgpt.com/codex/tasks/task_b_6895909195e483319545c6d1eeaef16d