### PR TITLE
Remove interactive prompt from standalone installer test cleanup

### DIFF
--- a/test_standalone_installer.py
+++ b/test_standalone_installer.py
@@ -191,11 +191,18 @@ def main():
         return False
     
     finally:
-        # Cleanup option
-        keep_files = input(f"\nKeep test files in {test_dir}? (y/N): ").lower().startswith('y')
+        # Cleanup test files unless explicitly asked to keep them via env var
+        keep_files = os.getenv("KEEP_STANDALONE_INSTALLER_TEST_FILES", "").lower() in (
+            "1",
+            "true",
+            "yes",
+            "y",
+        )
         if not keep_files:
-            shutil.rmtree(test_dir)
+            shutil.rmtree(test_dir, ignore_errors=True)
             print("🗑️  Test files cleaned up")
+        else:
+            print(f"📁 Test files kept in {test_dir}")
 
 if __name__ == "__main__":
     success = main()


### PR DESCRIPTION
## Summary
- Replace interactive input in `test_standalone_installer.py` with environment-variable based cleanup
- Ensure test script automatically deletes temp files unless `KEEP_STANDALONE_INSTALLER_TEST_FILES` is set

## Testing
- `python -m py_compile test_standalone_installer.py`
- `python test_standalone_installer.py > /tmp/test_output.log && tail -n 20 /tmp/test_output.log`


------
https://chatgpt.com/codex/tasks/task_b_68959091bab48331b450a37d7e362f4f